### PR TITLE
Fix typo in logging message

### DIFF
--- a/src/handlers/event-handler.js
+++ b/src/handlers/event-handler.js
@@ -15,7 +15,7 @@ const path = require("path");
 //     const fileInfo = await client.files.info({
 //       file: event.file_id,
 //     });
-//     yellow(`handing ${event.file_id}, here's the fileInfo;`)
+//     yellow(`handling ${event.file_id}, here's the fileInfo;`)
 //     yellow(fileInfo)
 //     if (event.channel_id == process.env.SLACK_EXTERNAL_LINKS_CHANNEL && handledImageFiles.includes(fileInfo.file.mimetype) ) {
 //       await handleImageFile(event, client, fileInfo)

--- a/src/utils/ll-slack-tools/event-handlers/handle-event.js
+++ b/src/utils/ll-slack-tools/event-handlers/handle-event.js
@@ -19,7 +19,7 @@ exports.fileShared = async ({ event, client}) => {
         const fileInfo = await client.files.info({
           file: event.file_id,
         });
-        yellow(`handing ${event.file_id}, here's the fileInfo;`)
+        yellow(`handling ${event.file_id}, here's the fileInfo;`)
         magenta(fileInfo)
       } else {
         gray(`file shared in non-work channel, we'll leave it alone for now`)


### PR DESCRIPTION
## Summary
- correct `handling` typo in handle-event.js
- update commented example in event-handler.js

## Testing
- `npm test` *(fails: Error: no test specified)*